### PR TITLE
Test harness for get_current_line_tab()

### DIFF
--- a/TabTestView.py
+++ b/TabTestView.py
@@ -1,0 +1,55 @@
+import console, ui
+
+class TabTestView(ui.View):
+    def __init__(self):
+        self.textview = ui.TextView()
+        self.textview.text = '\n'.join('{}{}'.format('\t' * i, i) for i in xrange(10))
+        self.add_subview(self.textview)
+        self.right_button_items = [ui.ButtonItem(action=self.button_action, image=ui.Image.named("ionicons-hammer-24"))]
+        self.present()
+        self.textview.frame = self.bounds
+
+    def button_action(self, sender):
+        self.get_current_line_tab(self.textview)
+
+    def get_current_line_tab(self, textview):
+        text, selection = textview.text, textview.selected_range
+        print(selection)
+        try:
+            ctext = text[selection[0] - 1 : selection[1] - 1]
+            print('ctext', ctext)
+            x = selection[1] - 1
+            while True:
+                c = text[x]
+                if c != "\n":
+                    ctext += c
+                    x += 1
+                else:
+                    break
+            x = selection[0] - 1
+            try:
+                while True:
+                    c = text[x]
+                    if c != "\n" and c != 0:
+                        ctext = c + ctext
+                        x -= 1
+                    else:
+                        break
+            except:
+                pass
+            print "%r" % ctext
+            tabs = ctext.count("\t")
+            print tabs
+            should_remove_one = True
+            for x in ctext:
+                if x != "\t":
+                    should_remove_one = False
+            if should_remove_one:
+                tabs -= 1
+        except:
+            tabs = 0
+        console.hud_alert('tabs: {}'.format(tabs))
+        self.tab_num = tabs
+
+print('=' * 25)
+TabTestView()

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ class DataSource(ui.ListDataSource):
         ui.ListDataSource.tableview_delete(self, tableview, section, row)
         #print "deleted_item", deleted_item
         del file_system["data"][deleted_item]
-        pickle.dump(file_system, fs_filename)
+        pickle_dump(file_system, fs_filename)
         
 
 #Classes first then functions
@@ -237,10 +237,7 @@ class TextViewDelegate(object):
         print len(textview.text)
         
         file_system["data"][self.file_name][0] = textview.text
-        
-        data = open("projects_data.pick", "w")
-        pickle.dump(file_system, data)
-        data.close()
+        pickle_dump(file_system, fs_filename)
         
         try:
             textview.selected_range = selection

--- a/main.py
+++ b/main.py
@@ -143,13 +143,7 @@ class ToolMenu(ui.View):
         self.open_tags_label.flex = "LRWB"
     
     def reload_label(self, tags):
-        if tags:
-            label = "Open Tags: " 
-            for x in tags:
-                label += x + ", "
-        else:
-            label = "No Open Tags"
-        
+        label = "Open Tags: " + ", ".join(tags) if tags else "No Open Tags"
         self.open_tags_label.text = label
     
 class TextViewDelegate(object):


### PR DESCRIPTION
I have been puzzled about the purpose of and the results from `get_current_line_tab()`.  This test harness lets us debug its behavior in isolation.

Does it return the intended result when you:
- put the insertion point before the first tab on line 4 and tap the hammer?
- put the insertion point just before the number 4 and tap the hammer?
- put the insertion point just after the number 4 and tap the hammer?
- select the number 4 and tap the hammer?
- select lines 4, 5, and 6 and tap the hammer?

Also see: https://realpython.com/blog/python/the-most-diabolical-python-antipattern and https://docs.python.org/2/howto/doanddont.html#except on why you should avoid bare exception statements.
